### PR TITLE
Update the git repository URL to Pagure.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=numad-git
 pkgver=0.5
-pkgrel=1
+pkgrel=2
 pkgdesc="numad is a deamon that monitors NUMA topology and usage and distributes loads for good locality for the purpose of providing the best performance, by avoiding unnecessary latency."
 arch=('x86_64' 'i686')
 license=('LGPL')
-url="https://git.fedorahosted.org/git/numad.git"
+url="https://pagure.io/numad.git"
 options=()
 depends=('cmake' 'libsystemd' 'git')
-source=("git+https://git.fedorahosted.org/git/numad.git")
+source=("git+https://pagure.io/numad.git")
 md5sums=('SKIP')
 
 build() {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # NUMA package for Archlinux AUR
 # numad is a deamon that monitors NUMA topology and usage and distributes loads for good locality for the purpose of providing the best performance, by avoiding unnecessary latency.	
-# source: https://git.fedorahosted.org/git/numad.git
+# source: https://pagure.io/numad


### PR DESCRIPTION
Fedora has moved repos from FedoraHosted to Pagure (pagure.io).